### PR TITLE
Updated dump.py functionality to Python 3

### DIFF
--- a/conv.py
+++ b/conv.py
@@ -9,7 +9,7 @@ but only if that can be done losslessly, and
 enum-like types to strings. Bitsets are converted to lists of true/false.
 '''
 
-import parser
+import korgparser as parser
 
 '''
 Conv() on its own is a no-op
@@ -45,7 +45,7 @@ Used for all the enum-like fields that aren't contiguous.
 class DictConv(Conv):
   def __init__(self, d):
     self.d = d
-    self.d_inv = {v: k for k, v in d.iteritems()}
+    self.d_inv = {v: k for k, v in d.items()}
 
   def from_file_repr(self, file_repr):
     return self.d[file_repr]

--- a/dump.py
+++ b/dump.py
@@ -20,9 +20,9 @@ if file_path.endswith('mnlgxdlib'):
     raise ValueError(Usage)
   patch_numbers = cmdline_util.patch_number_expr(sys.argv[2])
 else:
-  patch_numbers = xrange(0 , 1)
+  patch_numbers = range(0 , 1)
 
 for patch in patch_numbers:
   patch = mnlgxdprog.extract_patch(file_path, patch)
-  print patch.pretty_print()
-  print
+  print(patch.pretty_print())
+  print()

--- a/fileinformation.py
+++ b/fileinformation.py
@@ -42,14 +42,14 @@ def look_for(f, files, kind, suffix = None):
     id = m.group(1)
     info = info_fmt.format(id)
     if not info in files:
-      print 'Warning! Missing: {}'.format(info)
+      print('Warning! Missing: {}'.format(info))
 
   m = re.match(info_re, f)
   if m:
     id = m.group(1)
     binf = bin_fmt.format(id)
     if not binf in files:
-      print 'Warning! Missing: {}'.format(binf)
+      print('Warning! Missing: {}'.format(binf))
 
   return found
 
@@ -78,7 +78,7 @@ def mk_file_info_xml_from_dir(dir_path):
       tune_oct_data = tune_oct_data + 1
 
     else:
-      print 'Warning! Unexpected file: {}'.format(f)
+      print('Warning! Unexpected file: {}'.format(f))
 
   return mk_file_info_xml(patch_files, has_fave_data, tune_scale_data, tune_oct_data)
 

--- a/korgparser.py
+++ b/korgparser.py
@@ -1,0 +1,99 @@
+'''
+Parses binary files based on a provided schema, and applies conversions to more idiomatic python values.
+Conversions are specified in the given schema via Conv instances.
+'''
+
+import collections
+import inspect
+import struct
+
+'''
+A Parsed is dict-like but also carries its schema, and can be serialized back to its binary format.
+It can also be pretty printed.
+
+Schema should be a list of tuples, each of which in one of the following forms:
+  (name,binary_format) # implies no-op conv + no-op pretty printer
+  (name,binary_format, conv) # implies no-op pretty printer
+  (name,binary_format, conv, pretty_printer)
+
+binary_format is a string understood by the struct library
+
+conv is an instance of Conv that can handle the value that the struct library
+produces based on the given binary_format
+
+pretty_printer is a fucntion or None
+  if the function has arity of 1, it should be a function from value => pretty string
+  if the function has arity of 2, it should be a function from (parsed, value) => pretty string
+    where parsed is the Parsed instance being printed
+  if None the field won't be printed at all
+
+if pretty_printer is omitted str(value) will be used
+'''
+class Parsed(object):
+  def __init__(self, schema, data):
+    self.schema = schema
+    self.data = data
+
+  def __getitem__(self, key):
+    return self.data[key]
+
+  def __setitem__(self, key, value):
+    self.data[key] = value
+
+  def serialize(self):
+    format_string = ''.join(map(lambda x: x[1], self.schema))
+
+    file_repr_values = []
+
+    for field in self.schema:
+      name = field[0]
+      p = self.data[name]
+
+      if len(field) >= 3:
+        # invert conv
+        conv = field[2]
+        p = conv.to_file_repr(p)
+
+      file_repr_values.append(p)
+
+    return struct.pack(format_string, *file_repr_values)
+
+  def pretty_print(self):
+    printers = dict((x[0], x[3]) for x in self.schema if len(x) >= 4)
+
+    lines = []
+    for k,v in self.data.items():
+      pp = printers.get(k, lambda x : str(x))
+
+      if pp: # if pp is None we don't print anything
+        if len(inspect.getargspec(pp).args) == 1:
+          ppv = pp(v)
+        else:
+          ppv = pp(self.data, v)
+
+        lines.append('{} => {}'.format(k, ppv))
+
+    return '\n'.join(lines)
+
+def parse(binary, schema):
+  format_string = ''.join(map(lambda x: x[1], schema))
+  unpacked = struct.unpack(format_string, binary)
+
+  if len(unpacked) != len(schema):
+    raise ValueError('Expected to get back %d elements from struct.unpack but got %d' % (len(schema), len(unpacked)))
+
+  res = collections.OrderedDict()
+
+  for i,file_repr in enumerate(unpacked):
+    name = schema[i][0]
+
+    val = file_repr
+
+    if len(schema[i]) >= 3:
+      # apply conv
+      conv = schema[i][2]
+      val = conv.from_file_repr(file_repr)
+
+    res[name] = val
+
+  return Parsed(schema, res)

--- a/xd_prog_bin.py
+++ b/xd_prog_bin.py
@@ -9,7 +9,7 @@ import json
 import traceback
 
 from conv import *
-import parser
+import korgparser as parser
 
 def pitch_cents(value):
   if 0 <= value <= 4:
@@ -392,10 +392,10 @@ def pp_note(n):
 
 def pp_steps(parsed, ignored):
   steps = []
-  for i in xrange(1, 16):
+  for i in range(1, 16):
     data = parsed['step_{}_event_data'.format(i)]
     notes = []
-    for n in xrange(1, 8):
+    for n in range(1, 8):
       note = data['note_{}'.format(n)]
       vel = data['velocity_{}'.format(n)]
       if vel:
@@ -611,7 +611,8 @@ def assert_header(file_content):
     traceback.print_exc()
     raise ValueError('Could not unpack magic hader from file, is this in invalid file?')
 
-  if magic['magic'] != 'PROG':
+  if magic['magic'].decode("utf-8") != 'PROG':
+    print(magic['magic'])
     raise ValueError('File does not begin with magic header PROG')
 
 def parse(file_content):
@@ -622,7 +623,7 @@ def parse(file_content):
   parsed = parser.parse(file_content, FILE_SCHEMA)
 
   # seems unlikely but check the magic field again anyway
-  if (parsed['magic'] != 'PROG'):
+  if (parsed['magic'].decode("utf-8") != 'PROG'):
     raise ValueError('This doesn\'t look like a valid file, magic PROG header incorrect')
 
   return parsed


### PR DESCRIPTION
A few simple changes were required:

- Changed xrange to range 
- dict iteritems to items 
- parser renamed to korgparser (conflicted with python3 module of the same name)
- print statements converted to python3 prints